### PR TITLE
Added ARMCLANG compiler support for C/C++

### DIFF
--- a/cross/armclang.txt
+++ b/cross/armclang.txt
@@ -1,0 +1,20 @@
+# This file assumes that path to the arm compiler toolchain is added
+# to the environment(PATH) variable, so that Meson can find
+# the armclang, armlink and armar while building.
+[binaries]
+c = 'armclang'
+cpp = 'armclang'
+ar = 'armar'
+strip = 'armar'
+
+[properties]
+# The '--target', '-mcpu' options with the appropriate values should be mentioned
+# to cross compile c/c++ code with armclang.
+c_args      = ['--target=arm-arm-none-eabi', '-mcpu=cortex-m0plus']
+cpp_args    = ['--target=arm-arm-none-eabi', '-mcpu=cortex-m0plus']
+
+[host_machine]
+system = 'bare metal'      # Update with your system name - bare metal/OS.
+cpu_family = 'arm'
+cpu = 'Cortex-M0+'
+endian = 'little'

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -23,6 +23,7 @@ These are return values of the `get_id` method in a compiler object.
 | nagfor    | The NAG Fortran compiler       |
 | lcc       | Elbrus C/C++/Fortran Compiler  |
 | arm       | ARM compiler                   |
+| armclang  | ARMCLANG compiler              |
 
 ## Script environment variables
 

--- a/docs/markdown/snippets/armclang-cross.md
+++ b/docs/markdown/snippets/armclang-cross.md
@@ -1,0 +1,21 @@
+## ARM compiler(version 6) for C and CPP
+
+Cross-compilation is now supported for ARM targets using ARM compiler version 6 - ARMCLANG.
+The current implementation does not support shareable libraries.
+The default extension of the output is .axf.
+The environment path should be set properly for the ARM compiler executables.
+The '--target', '-mcpu' options with the appropriate values should be mentioned
+in the cross file as shown in the snippet below.
+
+```
+[properties]
+c_args      = ['--target=arm-arm-none-eabi', '-mcpu=cortex-m0plus']
+cpp_args    = ['--target=arm-arm-none-eabi', '-mcpu=cortex-m0plus']
+
+```
+
+Note:
+- The current changes are tested on Windows only.
+- PIC support is not enabled by default for ARM,
+  if users want to use it, they need to add the required arguments
+  explicitly from cross-file(c_args/c++_args) or some other way.

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -118,8 +118,9 @@ from .compilers import (
     IntelCompiler,
 )
 from .c import (
-    ArmCCompiler,
     CCompiler,
+    ArmCCompiler,
+    ArmclangCCompiler,
     ClangCCompiler,
     GnuCCompiler,
     ElbrusCCompiler,
@@ -127,8 +128,9 @@ from .c import (
     VisualStudioCCompiler,
 )
 from .cpp import (
-    ArmCPPCompiler,
     CPPCompiler,
+    ArmCPPCompiler,
+    ArmclangCPPCompiler,
     ClangCPPCompiler,
     GnuCPPCompiler,
     ElbrusCPPCompiler,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -32,6 +32,7 @@ from .compilers import (
     vs32_instruction_set_args,
     vs64_instruction_set_args,
     ArmCompiler,
+    ArmclangCompiler,
     ClangCompiler,
     Compiler,
     CompilerArgs,
@@ -922,6 +923,32 @@ class ClangCCompiler(ClangCompiler, CCompiler):
         if self.clang_type == compilers.CLANG_OSX:
             return basic + ['-Wl,-headerpad_max_install_names']
         return basic
+
+
+class ArmclangCCompiler(ArmclangCompiler, CCompiler):
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
+        ArmclangCompiler.__init__(self)
+        default_warn_args = ['-Wall', '-Winvalid-pch']
+        self.warn_args = {'1': default_warn_args,
+                          '2': default_warn_args + ['-Wextra'],
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+
+    def get_options(self):
+        return {'c_std': coredata.UserComboOption('c_std', 'C language standard to use',
+                                                  ['none', 'c90', 'c99', 'c11',
+                                                   'gnu90', 'gnu99', 'gnu11'],
+                                                  'none')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['c_std']
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
 
 
 class GnuCCompiler(GnuCompiler, CCompiler):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -28,6 +28,7 @@ from .compilers import (
     ElbrusCompiler,
     IntelCompiler,
     ArmCompiler,
+    ArmclangCompiler,
 )
 
 class CPPCompiler(CCompiler):
@@ -95,6 +96,32 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
     def language_stdlib_only_link_flags(self):
         return ['-lstdc++']
+
+
+class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
+        ArmclangCompiler.__init__(self)
+        default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
+        self.warn_args = {'1': default_warn_args,
+                          '2': default_warn_args + ['-Wextra'],
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+
+    def get_options(self):
+        return {'cpp_std': coredata.UserComboOption('cpp_std', 'C++ language standard to use',
+                                                    ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17'
+                                                     'gnu++98', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17'],
+                                                    'none')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['cpp_std']
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
 
 
 class GnuCPPCompiler(GnuCompiler, CPPCompiler):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -40,6 +40,8 @@ from .compilers import (
 from .compilers import (
     ArmCCompiler,
     ArmCPPCompiler,
+    ArmclangCCompiler,
+    ArmclangCPPCompiler,
     ClangCCompiler,
     ClangCPPCompiler,
     ClangObjCCompiler,
@@ -551,6 +553,22 @@ class Environment:
                     cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
                 return cls(ccache + compiler, version, gtype, is_cross, exe_wrap, defines, full_version=full_version)
 
+            if 'armclang' in out:
+                # The compiler version is not present in the first line of output,
+                # instead it is present in second line, startswith 'Component:'.
+                # So, searching for the 'Component' in out although we know it is
+                # present in second line, as we are not sure about the
+                # output format in future versions
+                arm_ver_str = re.search('.*Component.*', out)
+                if arm_ver_str is None:
+                    popen_exceptions[' '.join(compiler)] = 'version string not found'
+                    continue
+                arm_ver_str = arm_ver_str.group(0)
+                # Override previous values
+                version = search_version(arm_ver_str)
+                full_version = arm_ver_str
+                cls = ArmclangCCompiler if lang == 'c' else ArmclangCPPCompiler
+                return cls(ccache + compiler, version, is_cross, exe_wrap, full_version=full_version)
             if 'clang' in out:
                 if 'Apple' in out or mesonlib.for_darwin(want_cross, self):
                     cltype = CLANG_OSX


### PR DESCRIPTION
- The changes include support for cross-compiling C and C++ code with ARMCLANG.
- 'armlink' is used as linker internally, so the path to armlink should be set in the user environment PATH variable before running meson.
- Building shareable libraries is not supported with current implementation.
- The PIC support related options are expected to be added by user explicitly.
- The current implementation doesn't have support for compiling assembly files with arm syntax.
- The 'target' compiler command line option is required to be set for running the sanity check, so passing this option from cross-file, cross/armclang.txt.

The changes are tested on Windows with ARM compiler version 6.5(MDK 5.21).
The attached files are the cross test results obtained from running the following command line
**python .\run_cross_test.py cross\armclang.txt**
[armclang_cross_test_log.txt](https://gist.github.com/sompen/c0e64d52f2566217d9e6933680b3bfcb)
[meson-cross-test-run.txt](https://gist.github.com/sompen/145b985bb7587da41eb098a6c0e63876)
[meson-cross-test-run.xml](https://gist.github.com/sompen/1f4b2a01ebcd892ede60f629f226502a)

Currently out of 198 cross tests - 45 are failing, 4 are being skipped and 148 tests are passing.
